### PR TITLE
False positive 500 error on valid https links

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@
 flake8
 nose
 coverage
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ html2text==2014.12.29
 lxml==3.4.1
 parse==1.6.6
 aiohttp==0.20.2
+requests==2.13.0
+pyOpenSSL==16.2.0

--- a/tests/test_check_url.py
+++ b/tests/test_check_url.py
@@ -119,6 +119,12 @@ class TestTxt(AsyncTestCase):
         mock_get.assert_called_with('get', 'http://bit.ly/UpdateKeepSafe', headers={})
 
     @patch('aiohttp.request')
+    def test_skip_keepsafe_urls(self, mock_get):
+        self._check(mock_get, 'aaa keepsafe://access.getkeepsafe.com/upgrade/email-premium-hint aaa', 200)
+
+        self.assertFalse(mock_get.called)
+
+    @patch('aiohttp.request')
     def test_check_headers(self, mock_get):
         headers = {'User-Agent': 'Keepsafe'}
         self.check = url.UrlValidator('txt', headers=headers)
@@ -192,6 +198,13 @@ class TestHtml(AsyncTestCase):
         self._check(mock_get, '<a href="support@getkeepsafe.com"></a>', 200)
 
         self.assertFalse(mock_get.called)
+
+    @patch('aiohttp.request')
+    def test_skip_keepsafe_urls(self, mock_get):
+        errors = self._check(mock_get, '<a href="keepsafe://access.getkeepsafe.com/upgrade/email-premium-hint"></a>', 200)
+
+        self.assertFalse(mock_get.called)
+        self.assertEqual([], errors)
 
     @patch('aiohttp.request')
     def test_skip_images(self, mock_get):

--- a/tests/test_check_url.py
+++ b/tests/test_check_url.py
@@ -201,7 +201,9 @@ class TestHtml(AsyncTestCase):
 
     @patch('aiohttp.request')
     def test_skip_keepsafe_urls(self, mock_get):
-        errors = self._check(mock_get, '<a href="keepsafe://access.getkeepsafe.com/upgrade/email-premium-hint"></a>', 200)
+        errors = self._check(mock_get,
+                             '<a href="keepsafe://access.getkeepsafe.com/upgrade/email-premium-hint"></a>',
+                             200)
 
         self.assertFalse(mock_get.called)
         self.assertEqual([], errors)

--- a/validator/checks/url.py
+++ b/validator/checks/url.py
@@ -20,7 +20,7 @@ class TextUrlExtractor(object):
     def __init__(self, **kwargs):
         pass
 
-    url_pattern = r'(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()\[\]<>]' \
+    url_pattern = r'(?i)\b((?:https?://|www\d{0,3}[.]|(!keepsafe://)[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()\[\]<>]' \
         '+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[' \
         '\];:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))'
 

--- a/validator/checks/url.py
+++ b/validator/checks/url.py
@@ -3,6 +3,7 @@ import logging
 import asyncio
 import aiohttp
 import string
+import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin
 
@@ -90,17 +91,26 @@ class UrlStatusChecker(object):
         self._headers = headers
 
     def _make_request(self, url):
+        status = None
         res = None
         try:
             logging.info('checking {}'.format(url))
             res = yield from aiohttp.request('get', url, headers=self._headers)
-            return res.status
+            status = res.status
         except Exception:
             logging.error('Error making request to %s', url)
-            return 500
         finally:
             if res:
                 res.close()
+
+        if not status:
+            try:
+                logging.info('backup checking {}'.format(url))
+                status = requests.get(url).status_code
+            except Exception:
+                logging.error('Error making backup request to %s', url)
+                status = 500
+        return status
 
     def _retry_request(self, url, status):
         new_status = status


### PR DESCRIPTION
Related to Keepsafe/emails#27

There isn't any 500 status, but SSL handshake failure.
Source of this seems to be old `OpenSSL 0.9.8zh 14 Jan 2016` on macOS and Apple doesn't allow to update that in easy way for security reasons.

URL check uses `aiohttp` which forces to use python's `ssl` lib.
I found a workaround using `pyOpenSSL` and `requests`  which behaves correctly on old `OpenSSL`. 