### PR TITLE
chore: release Markdown dependency version lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.4.1
-Markdown==2.6.11
+Markdown
 html2text==2014.12.29
 lxml==3.5
 parse==1.8.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(f):
 
 install_requires = [
     'aiohttp >=3, <3.4',
-    'Markdown >=2, <3',
+    'Markdown',
     'parse >=1, <2',
     'beautifulsoup4 >=4, <5',
     'lxml >=3',


### PR DESCRIPTION
content-validator is used in:
- zendesk-editor that depends on ks-markdown which requires `Markdown` >= 3
- email-service that depends on email-parser which requires `Markdown` < 3
- realtime-translation-validator

Markdown itself is used in content validator only to render a preview for the end-user [ref](https://github.com/KeepSafe/content-validator/blob/master/validator/checks/md.py#L25)

The goal of releasing version lock is allowing to install appropriate `Markdown` version depending of the context where the lib is used (zendesk editor vs email-service)